### PR TITLE
Vulkan/DX12 : refactor cull face code (#1849)

### DIFF
--- a/rpcs3/Emu/RSX/D3D12/D3D12Formats.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Formats.cpp
@@ -382,6 +382,17 @@ BOOL get_front_face_ccw(u32 ffv)
 	throw EXCEPTION("Invalid front face value (0x%x)", ffv);
 }
 
+D3D12_CULL_MODE get_cull_face(u32 cfv) 
+{
+	switch (cfv)
+	{
+	case CELL_GCM_FRONT: return D3D12_CULL_MODE_FRONT;
+	case CELL_GCM_BACK:  return D3D12_CULL_MODE_BACK;
+	default: return D3D12_CULL_MODE_NONE;
+	}
+	throw EXCEPTION("Invalid cull face value (0x%x)", cfv);
+}
+
 DXGI_FORMAT get_index_type(rsx::index_array_type index_type)
 {
 	switch (index_type)

--- a/rpcs3/Emu/RSX/D3D12/D3D12Formats.h
+++ b/rpcs3/Emu/RSX/D3D12/D3D12Formats.h
@@ -94,6 +94,11 @@ DXGI_FORMAT get_depth_samplable_surface_format(rsx::surface_depth_format format)
 BOOL get_front_face_ccw(u32 set_front_face_value);
 
 /**
+* Convert cull face value to a D3D12_CULL_MODE telling wheter cull face is front or back
+*/
+D3D12_CULL_MODE get_cull_face(u32 set_cull_face_value);
+
+/**
  * Convert index type to DXGI_FORMAT
  */
 DXGI_FORMAT get_index_type(rsx::index_array_type index_type);

--- a/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
+++ b/rpcs3/Emu/RSX/D3D12/D3D12PipelineState.cpp
@@ -202,23 +202,11 @@ void D3D12GSRender::load_program()
 		D3D12_CONSERVATIVE_RASTERIZATION_MODE_OFF,
 	};
 	prop.Rasterization = CD3D12_RASTERIZER_DESC;
+	
 	if (!!rsx::method_registers[NV4097_SET_CULL_FACE_ENABLE])
 	{
-		switch (rsx::method_registers[NV4097_SET_CULL_FACE])
-		{
-		case CELL_GCM_FRONT:
-			prop.Rasterization.CullMode = D3D12_CULL_MODE_FRONT;
-			break;
-		case CELL_GCM_BACK:
-			prop.Rasterization.CullMode = D3D12_CULL_MODE_BACK;
-			break;
-		default:
-			prop.Rasterization.CullMode = D3D12_CULL_MODE_NONE;
-			break;
-		}
+		prop.Rasterization.CullMode = get_cull_face(rsx::method_registers[NV4097_SET_CULL_FACE]);
 	}
-	else
-		prop.Rasterization.CullMode = D3D12_CULL_MODE_NONE;
 
 	prop.Rasterization.FrontCounterClockwise = get_front_face_ccw(rsx::method_registers[NV4097_SET_FRONT_FACE]);
 

--- a/rpcs3/Emu/RSX/VK/VKFormats.h
+++ b/rpcs3/Emu/RSX/VK/VKFormats.h
@@ -15,6 +15,7 @@ namespace vk
 	VkStencilOp get_stencil_op(u32 op);
 	VkLogicOp get_logic_op(u32 op);
 	VkFrontFace get_front_face_ccw(u32 ffv);
+	VkCullModeFlags get_cull_face(u32 cfv);
 	VkBorderColor get_border_color(u8 color);
 
 	std::tuple<VkFilter, VkSamplerMipmapMode> get_min_filter_and_mip(rsx::texture_minify_filter min_filter);

--- a/rpcs3/Emu/RSX/VK/VKGSRender.cpp
+++ b/rpcs3/Emu/RSX/VK/VKGSRender.cpp
@@ -269,6 +269,18 @@ namespace vk
 		}
 		throw EXCEPTION("Unknown front face value: 0x%X", ffv);
 	}
+
+	VkCullModeFlags get_cull_face(u32 cfv)
+	{
+		switch (cfv)
+		{
+		case CELL_GCM_FRONT: return VK_CULL_MODE_FRONT_BIT;
+		case CELL_GCM_BACK: return VK_CULL_MODE_BACK_BIT;
+		case CELL_GCM_FRONT_AND_BACK: return VK_CULL_MODE_FRONT_AND_BACK;
+		default: return VK_CULL_MODE_NONE;
+		}
+		throw EXCEPTION("Unknown cull face value: 0x%X", cfv);
+	}
 }
 
 
@@ -992,24 +1004,8 @@ bool VKGSRender::load_program()
 
 	if (!!rsx::method_registers[NV4097_SET_CULL_FACE_ENABLE])
 	{
-		switch (rsx::method_registers[NV4097_SET_CULL_FACE])
-		{
-		case CELL_GCM_FRONT:
-			properties.rs.cullMode = VK_CULL_MODE_FRONT_BIT;
-			break;
-		case CELL_GCM_BACK:
-			properties.rs.cullMode = VK_CULL_MODE_BACK_BIT;
-			break;
-		case CELL_GCM_FRONT_AND_BACK:
-			properties.rs.cullMode = VK_CULL_MODE_FRONT_AND_BACK;
-			break;
-		default:
-			properties.rs.cullMode = VK_CULL_MODE_NONE;
-			break;
-		}
+		properties.rs.cullMode = vk::get_cull_face(rsx::method_registers[NV4097_SET_CULL_FACE]);
 	}
-	else
-		properties.rs.cullMode = VK_CULL_MODE_NONE;
 	
 	properties.rs.frontFace = vk::get_front_face_ccw(rsx::method_registers[NV4097_SET_FRONT_FACE]);
 	


### PR DESCRIPTION
* Vulkan/DX12 : refactor cull face code

1

* Add optimal build options to CMakeLists (#1841)

Provides two options when building RPCS3

    USE_SYSTEM_FFMPEG BOOL (default: OFF)
    USE_SYSTEM_LIBPNG BOOL (default: OFF)

These options lets the user select between the system provided and builtin libraries of ffmpeg and libpng to overcome possible system issues.

Also adds support for older libpng releases if the user doesn't have libpng 1.5 or higher.

* DX12: depth buffer compare should perform only if depth testing is enabled (#1848)

* GL: front face regression fix (#1854)

* GUI: Add bulk decryption of LLE modules (#1845)

Adds a new menu to "Tools" called "&Decrypt SPRX libraries" which opens a dialog to select
multiple *.sprx files, which are than decrypted all at once.
This speeds up the LLE module decryption and saves users a lot of time.

The output path is the same where the input module resides and the extension is changed
to *.prx

* vk: Avoid double-copy for vertex attributes (#1852)

* vk: Avoid double-copy for vertex attributes

fix buffer overflow

vk: Fix vertex attrib offset_in_dst for batched draw calls

* whitespace fix only